### PR TITLE
Add document type groupings

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -1,0 +1,25 @@
+# Groups used for navigation.
+navigation_document_supertype:
+  - id: guidance
+    document_types:
+      - answer
+      - contact
+      - detailed_guide
+      - document_collection
+      - form
+      - guidance
+      - guide
+      - licence
+      - local_transaction
+      - manual
+      - map
+      - notice
+      - place
+      - programme
+      - promotional
+      - regulation
+      - simple_smart_answer
+      - smart_answer
+      - statutory_guidance
+      - transaction
+      - travel_advice

--- a/lib/govuk_document_types.rb
+++ b/lib/govuk_document_types.rb
@@ -1,5 +1,20 @@
 require "govuk_document_types/version"
+require "yaml"
 
 module GovukDocumentTypes
-  # Your code goes here...
+  def self.supertypes(document_type:)
+    @supertypes ||= YAML.load_file(File.dirname(__FILE__) + "/../data/supertypes.yml")
+
+    types = {}
+
+    @supertypes.each do |name, ary|
+      group_data = ary.find do |supertype|
+        supertype['document_types'].include?(document_type)
+      end
+
+      types.merge!(name => (group_data && group_data["id"]))
+    end
+
+    types
+  end
 end

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -4,4 +4,18 @@ describe GovukDocumentTypes do
   it "has a version number" do
     expect(GovukDocumentTypes::VERSION).not_to be nil
   end
+
+  describe '.supertypes' do
+    it 'returns a supertype for a known document type' do
+      supertypes = GovukDocumentTypes.supertypes(document_type: 'detailed_guide')
+
+      expect(supertypes).to eql({ "navigation_document_supertype" => "guidance" })
+    end
+
+    it 'returns nil for a known document type' do
+      supertypes = GovukDocumentTypes.supertypes(document_type: 'something_not_there')
+
+      expect(supertypes).to eql({ "navigation_document_supertype" => nil })
+    end
+  end
 end


### PR DESCRIPTION
First implementation of the document type groupings. Will be used by rummager and publishing-api to add data to search & documents. This is turn will be used by the new navigation pages and the email system. 

## Usage

You will be able to query search like this:

```
https://www.gov.uk/api/search.json?filter_navigation_document_supertype=guidance
https://www.gov.uk/api/search.json?filter_whitehall_document_supertype=publication
```

And the content-store, message queue will return a content item like this:

```ruby
{
  analytics_identifier: null,
  base_path: "/my-page",
  content_id: "11d5d2ad-b8ce-4b40-b12c-4efd90199b60",
  document_type: "detailed_guidance",
  navigation_document_supertype: "guidance",
  whitehall_document_supertype: "publication",
}
```

https://trello.com/c/07lAcDtC