### PR TITLE
Use "other" when there's no supertype for a document type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* When a document type isn't in a group, we'll set it to "other"
+
 # 0.1.1
 
 * Initial release.

--- a/lib/govuk_document_types.rb
+++ b/lib/govuk_document_types.rb
@@ -2,12 +2,12 @@ require "govuk_document_types/version"
 require "yaml"
 
 module GovukDocumentTypes
-  def self.supertypes(document_type:)
-    @supertypes ||= YAML.load_file(File.dirname(__FILE__) + "/../data/supertypes.yml")
+  DATA = YAML.load_file(File.dirname(__FILE__) + "/../data/supertypes.yml")
 
+  def self.supertypes(document_type:)
     types = {}
 
-    @supertypes.each do |name, ary|
+    DATA.each do |name, ary|
       group_data = ary.find do |supertype|
         supertype['document_types'].include?(document_type)
       end

--- a/lib/govuk_document_types.rb
+++ b/lib/govuk_document_types.rb
@@ -12,7 +12,8 @@ module GovukDocumentTypes
         supertype['document_types'].include?(document_type)
       end
 
-      types.merge!(name => (group_data && group_data["id"]))
+      type = (group_data && group_data["id"]) || "other"
+      types.merge!(name => type)
     end
 
     types

--- a/spec/data_lint_spec.rb
+++ b/spec/data_lint_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe GovukDocumentTypes do
+  describe 'supertypes.yml' do
+    it "does not have duplicates across supertypes" do
+      GovukDocumentTypes::DATA.each do |supertype_name, supertypes|
+        all_supertypes = supertypes.reduce([]) do |a, supertype|
+          a + supertype['document_types']
+        end
+
+        all_supertypes.uniq.each do |e|
+          next if all_supertypes.count(e) == 1
+
+          raise "The document type '#{e}' occurs in multiple groups in #{supertype_name}"
+        end
+      end
+    end
+  end
+end

--- a/spec/data_lint_spec.rb
+++ b/spec/data_lint_spec.rb
@@ -15,5 +15,13 @@ describe GovukDocumentTypes do
         end
       end
     end
+
+    it "reserves 'other' for document types without a group" do
+      GovukDocumentTypes::DATA.each do |_, supertypes|
+        supertypes.each do |supertype|
+          expect(supertype.fetch("id")).not_to eql("other")
+        end
+      end
+    end
   end
 end

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -12,10 +12,10 @@ describe GovukDocumentTypes do
       expect(supertypes).to eql("navigation_document_supertype" => "guidance")
     end
 
-    it 'returns nil for a known document type' do
+    it 'returns "other" for a known document type' do
       supertypes = GovukDocumentTypes.supertypes(document_type: 'something_not_there')
 
-      expect(supertypes).to eql("navigation_document_supertype" => nil)
+      expect(supertypes).to eql("navigation_document_supertype" => "other")
     end
   end
 end


### PR DESCRIPTION
Using `nil` is ambiguous. When there's no document type chosen, we explicitly set the supertype to "other".

https://trello.com/c/07lAcDtC
