### PR TITLE
Delete unnecessary schema checkout from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,10 +15,6 @@ node {
       govuk.mergeMasterBranch()
     }
 
-    stage("Set up content schema dependency") {
-      govuk.contentSchemaDependency()
-    }
-
     stage('Bundle') {
       echo 'Bundling'
       sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME}")


### PR DESCRIPTION
This project doesn't depend on the content schemas, so it doesn't need to check out a copy of the schemas before running the tests.