### PR TITLE
Remove `notice` from guidance document types

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -16,7 +16,6 @@ navigation_document_supertype:
         - local_transaction
         - manual
         - map
-        - notice
         - place
         - programme
         - promotional


### PR DESCRIPTION
After looking at the `notice` content which has been tagged to taxons, we've decided that it shouldn't appear on taxonomy navigation pages.

Trello: https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list