### PR TITLE
Start docs for adding a supertype

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,19 @@
-The MIT License (MIT)
+Copyright (C) 2017 Crown copyright (Government Digital Service)
 
-Copyright (c) 2017 Tijmen Brommet
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,40 @@
-# GovukDocumentTypes
+# GOV.UK document types
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/govuk_document_types`. To experiment with that code, run `bin/console` for an interactive prompt.
+This gem contains the "document supertypes" for GOV.UK. Supertypes are groupings
+of document types.
 
-TODO: Delete this and the text above, and describe your gem
+https://docs.publishing.service.gov.uk/document-types.html
 
-## Installation
+This gem is only to be used in [publishing-api][publishing-api] and
+[rummager][rummager]. **Don't use it in your project**.
 
-Add this line to your application's Gemfile:
+## How to add a supertype
 
-```ruby
-gem 'govuk_document_types'
+1. Add it to [data/supertypes.yml](data/supertypes.yml) in this gem and release a new version
+2. [Add the supertype][rummager-pr] in Rummager so that it can be indexed and searched with. Bump the gem in Rummager.
+3. [Add the type to content-schemas][schemas-pr]
+4. [Add the type to the content-store][content-store-pr]
+5. Bump the gem version in [publishing-api][publishing-api]
+
+## How to update a supertype
+
+1. Update [data/supertypes.yml](data/supertypes.yml) in this gem and release a new version.
+2. Bump the gem version in [rummager][rummager]. Rummager's nightly re-indexing will pick up your changes.
+3. Bump the gem version in [publishing-api][publishing-api]. All documents have to be sent to the content-store again for your changes to be picked up.
+
+## Running the test suite
+
 ```
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install govuk_document_types
-
-## Usage
-
-TODO: Write usage instructions here
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/govuk_document_types.
-
+bundle exec rake
+```
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+[MIT License](LICENSE.txt)
 
+[rummager-pr]: https://github.com/alphagov/rummager/pull/756
+[schemas-pr]: https://github.com/alphagov/govuk-content-schemas/pull/551
+[content-store-pr]: https://github.com/alphagov/content-store/pull/268
+
+[publishing-api]: https://github.com/alphagov/publishing-api
+[rummager]: https://github.com/alphagov/rummager


### PR DESCRIPTION
This updates the README and adds the appropriate license.

👉  [Rendered version](https://github.com/alphagov/govuk_document_types/blob/54028753db6f021fab60f4e642e73a5e1a504b28/README.md)

https://trello.com/c/07lAcDtC