### PR TITLE
Add email and government supertypes

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -50,3 +50,136 @@ user_journey_document_supertype:
         - taxon
         - topic
         - topical_event
+
+email_document_supertype:
+  name: "Email document type"
+  description: "High level group for email subscriptions use to identify publications and announcement"
+  default: other
+  items:
+    - id: "publications"
+      document_types:
+        - closed_consultation
+        - consultation
+        - consultation_outcome
+        - corporate_report
+        - correspondence
+        - decision
+        - foi_release
+        - form
+        - guidance
+        - impact_assessment
+        - independent_report
+        - international_treaty
+        - map
+        - national_statistics
+        - notice
+        - official_statistics
+        - open_consultation
+        - policy_paper
+        - promotional
+        - regulation
+        - research
+        - statistical_data_set
+        - statutory_guidance
+        - transparency
+    - id: "announcements"
+      document_types:
+        - announcement
+        - fatality_notice
+        - government_response
+        - news_story
+        - oral_statement
+        - press_release
+        - speech
+        - written_statement
+
+government_document_supertype:
+  name: "Government document type"
+  description: "Grouping for email subscriptions."
+  # we expect that everything should be mapped to a valid supertype.
+  default: other
+  items:
+    - id: consultations
+      document_types:
+        - consultation
+    - id: open-consultations
+      document_types:
+        - open_consultation
+    - id: closed-consultations
+      document_types:
+        - consultation_outcome
+        - closed_consultation
+    - id: policy-papers
+      document_types:
+        - policy_paper
+    - id: guidance
+      document_types:
+        - guidance
+        - statutory_guidance
+    - id: impact-assessments
+      document_types:
+        - impact_assessment
+    - id: independent-reports
+      document_types:
+        - independent_report
+    - id: correspondence
+      document_types:
+        - correspondence
+    - id: research-and-analysis
+      document_types:
+        - research
+    - id: statistics
+      document_types:
+        - official_statistics
+        - national_statistics
+        - statistical_data_set
+    - id: corporate-reports
+      document_types:
+        - corporate_report
+    - id: transparency-data
+      document_types:
+        - transparency
+    - id: foi-releases
+      document_types:
+        - foi_release
+    - id: forms
+      document_types:
+        - form
+    - id: maps
+      document_types:
+        - map
+    - id: international-treaties
+      document_types:
+        - international_treaty
+    - id: promotional-material
+      document_types:
+        - promotional
+    - id: notices
+      document_types:
+        - notice
+    - id: decisions
+      document_types:
+        - decision
+    - id: regulations
+      document_types:
+        - regulation
+    - id: press-releases
+      document_types:
+        - press_release
+    - id: news-stories
+      document_types:
+        - news_story
+        - announcement
+    - id: fatality-notices
+      document_types:
+        - fatality_notice
+    - id: speeches
+      document_types:
+        - speech
+    - id: statements
+      document_types:
+        - written_statement
+        - oral_statement
+    - id: government-responses
+      document_types:
+        - government_response


### PR DESCRIPTION
This adds some new super type fields to support the
migration from govuk_delivery to email_alert_api.

The following difference in filtered content will exists 
for government document super type as a result of these 
changes:

* Statement no longer includes content with a speeches 
document type that are statements to parliament
* Speeches now includes content with a speeches document 
type that are statements to parliament
* Press releases no longer includes content with an
announcements document type (these are still included in 
New Stories). These are left over from 2013 migration.
* Removed 'All consultations' filtering as this would
result in content being assigned to multiple government
super types. This will need to be expanded to match: 
Open consultations, Close consultations and Consultations.
* Added 'Consultations' as a supertype, this is to help 
support 'All consultations' filtering (see above)

https://trello.com/c/5yVMib2f/124-2-add-support-for-whitehall-topics-in-new-email-stack