### PR TITLE
Add schema testing for valid document types

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,46 +1,6 @@
 #!/usr/bin/env groovy
 
-REPOSITORY = 'govuk_document_types'
-
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-
-  try {
-    stage('Checkout') {
-      checkout scm
-    }
-
-    stage('Clean') {
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-    }
-
-    stage('Bundle') {
-      echo 'Bundling'
-      sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME}")
-    }
-
-    stage('Linter') {
-      govuk.rubyLinter()
-    }
-
-    stage('Tests') {
-      govuk.setEnvar('RAILS_ENV', 'test')
-      govuk.runTests('spec')
-    }
-
-    if(env.BRANCH_NAME == "master") {
-      stage('Publish Gem') {
-        govuk.publishGem(REPOSITORY, env.BRANCH_NAME)
-      }
-    }
-
-  } catch (e) {
-    currentBuild.result = 'FAILED'
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject()
 }

--- a/spec/data_lint_spec.rb
+++ b/spec/data_lint_spec.rb
@@ -38,7 +38,7 @@ describe GovukDocumentTypes do
       schema_directory = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../govuk-content-schemas"
       allowed_document_types = YAML.load_file("#{schema_directory}/lib/govuk_content_schemas/allowed_document_types.yml")
 
-      document_types = GovukDocumentTypes::DATA.flat_map do |name, definition|
+      document_types = GovukDocumentTypes::DATA.flat_map do |_name, definition|
         definition["items"].flat_map do |supertype|
           supertype["document_types"]
         end

--- a/spec/data_lint_spec.rb
+++ b/spec/data_lint_spec.rb
@@ -33,5 +33,17 @@ describe GovukDocumentTypes do
         end
       end
     end
+
+    it "contains only valid document types" do
+      allowed_document_types = YAML.load_file("../govuk-content-schemas/lib/govuk_content_schemas/allowed_document_types.yml")
+
+      document_types = GovukDocumentTypes::DATA.flat_map do |name, definition|
+        definition["items"].flat_map do |supertype|
+          supertype["document_types"]
+        end
+      end
+
+      expect(document_types - allowed_document_types).to eql([])
+    end
   end
 end

--- a/spec/data_lint_spec.rb
+++ b/spec/data_lint_spec.rb
@@ -35,7 +35,8 @@ describe GovukDocumentTypes do
     end
 
     it "contains only valid document types" do
-      allowed_document_types = YAML.load_file("../govuk-content-schemas/lib/govuk_content_schemas/allowed_document_types.yml")
+      schema_directory = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../govuk-content-schemas"
+      allowed_document_types = YAML.load_file("#{schema_directory}/lib/govuk_content_schemas/allowed_document_types.yml")
 
       document_types = GovukDocumentTypes::DATA.flat_map do |name, definition|
         definition["items"].flat_map do |supertype|


### PR DESCRIPTION
This adds a test that verifies that the document types we're using in the lists are valid according to the schema. Will prevent typos and drift.

Also moves to the new Jenkins script so that we have the schemas available on CI.