### PR TITLE
Remove announcement sub type for government_document_supertype

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -84,7 +84,6 @@ email_document_supertype:
         - transparency
     - id: "announcements"
       document_types:
-        - announcement
         - fatality_notice
         - government_response
         - news_story
@@ -169,7 +168,6 @@ government_document_supertype:
     - id: news-stories
       document_types:
         - news_story
-        - announcement
     - id: fatality-notices
       document_types:
         - fatality_notice


### PR DESCRIPTION
We've done the work to remove the Unknown NewsArticleType from Whitehall. This type was used for uncategorised NewsArticles, which have now been turned into NewsStories or PressReleases.
The Unknown Type would default to a document_type of 'announcement' which was quite confusing. Since we've removed all data for the Unknown NewsArticleTypes, this is not used any more and can be removed from this repo.

For https://trello.com/c/K1OAcdZ1/118-documents-with-an-unknown-newsarticletype-are-interfering-with-matching