### PR TITLE
Remove open-consultation and closed-consultation government document types

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -102,11 +102,7 @@ government_document_supertype:
     - id: consultations
       document_types:
         - consultation
-    - id: open-consultations
-      document_types:
         - open_consultation
-    - id: closed-consultations
-      document_types:
         - consultation_outcome
         - closed_consultation
     - id: policy-papers


### PR DESCRIPTION
Assign open_consultation, consultation_outcome and closed_consultation to the consultations government document type. This will ensure that users who try to subscribe to either open or closed consultations on gov.uk/government/publications will get emails for all consultations.

For https://trello.com/c/qv1l3WBy/119-documents-that-are-open-or-closed-consultations-dont-match-all-consultations-topics-in-email-alert-api