### PR TITLE
Add email_document_supertype > announcements > world_news_story

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -90,6 +90,7 @@ email_document_supertype:
         - oral_statement
         - press_release
         - speech
+        - world_news_story
         - written_statement
 
 government_document_supertype:


### PR DESCRIPTION
The subscriber lists in email-alert-api have an
email_document_supertype of announcements, but
we're sending this through as 'other' for these
document types. This means we don't match those
subscriber lists and some people wouldn't get
notified if we switched to sending through
email-alert-api instead of govuk-delivery. This
fixes that.

For example:

```
$ rake email_topics:check[5f101654-7631-11e4-a3cb-005056011aef]

{ ..., :email_document_supertype=>"other", ... }

additional govuk-delivery topics:
UKGOVUK_12298
UKGOVUK_2332
UKGOVUK_3055

$ govuk_app_console email-alert-api
> SubscriberList.find_by(gov_delivery_id: "UKGOVUK_3055")

#<SubscriberList id: 3797, ..., email_document_supertype: "announcements", ...>
```