### PR TITLE
Version bump: 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.6
+
+* Move all consultation document types under the same email_document_supertype
+to resolve a problem with subscriber lists we've never emailed from Whitehall
+
 # 0.1.5
 
 * Add email_document_supertype > announcements > world_news_story to fix some

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "0.1.5".freeze
+  VERSION = "0.1.6".freeze
 end


### PR DESCRIPTION
Changelog:

Move all consultation document types under the same email_document_supertype
to resolve a problem with subscriber lists we've never emailed from Whitehall