### PR TITLE
Add authored_article to the announcments email supertype

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -84,6 +84,7 @@ email_document_supertype:
         - transparency
     - id: "announcements"
       document_types:
+        - authored_article
         - fatality_notice
         - government_response
         - news_story


### PR DESCRIPTION
We added `authored_article` with a `government_document_supertype` of `statements` yesterday but we also need it to have a `email_document_supertype` for it to match the `announcements` subscriber lists.