### PR TITLE
Add search_user_need_document_supertype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add search_user_need_document_supertype for boosting search results for certain document types
+
 # 0.1.8
 
 * Include authored_article in announcements email_super_type

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -51,6 +51,22 @@ user_journey_document_supertype:
         - topic
         - topical_event
 
+search_user_need_document_supertype:
+  name: "Search user need"
+  description: "Used to group documents based on user need, core for mainstream users and government for specialist users in search results"
+  default: government
+  items:
+    - id: core
+      document_types:
+        - answer
+        - guide
+        - local_transaction
+        - place
+        - simple_smart_answer
+        - smart_answer
+        - transaction
+        - travel_advice
+
 email_document_supertype:
   name: "Email document type"
   description: "High level group for email subscriptions use to identify publications and announcement"


### PR DESCRIPTION
This will be used to group documents by core or government. In the short term this will be used in an A/B test to boost core (sometimes referred to as 'mainstream') documents in search
results.

https://trello.com/c/z9wtoGTV