### PR TITLE
Add calendar document type to search user need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add calendar document type to search_user_need_document_supertype
+* Add calendar document type to navigation_document_supertype
 
 # 0.1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add calendar document type to search_user_need_document_supertype
+
 # 0.1.9
 
 * Add search_user_need_document_supertype for boosting search results for certain document types

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -6,6 +6,7 @@ navigation_document_supertype:
     - id: guidance
       document_types:
         - answer
+        - calendar
         - contact
         - detailed_guide
         - document_collection

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -59,6 +59,7 @@ search_user_need_document_supertype:
     - id: core
       document_types:
         - answer
+        - calendar
         - guide
         - local_transaction
         - place


### PR DESCRIPTION
- Add calendar document type to search_user_need as it is also considered to be 'core' content.
- Add  calendar document type to navigation_document_supertype as it is also considered to be a form of guidance.

https://trello.com/c/z9wtoGTV