### PR TITLE
Add new content purpose sub and supergroups

### DIFF
--- a/data/content_purpose_supergroups.md
+++ b/data/content_purpose_supergroups.md
@@ -1,0 +1,20 @@
+# Content Purpose Supergroups
+
+These are the grouping that the navigation team came up with
+as a result of an investigation done using the "Jobs to be Done" framework in Q4.
+
+There are 5 high level Content Purpose Supergroups which each group together some subgroups
+which in turn group `document_types`.
+
+More information about the JTBD framework and the supergroups can be found on the
+[GovUK wiki](https://gov-uk.atlassian.net/wiki/spaces/GFED/pages/305201156/Document+type+groupings)
+
+The list of which document types are grouped by both supergroups and subgroups can be
+found in the [supertypes.yml](./supertypes.yml) file.
+
+The list of the subgroups grouped by supergroup are in the file [supergroups.yml](./supergroups.yml).
+If you want to make a change to the `document_type` groupings in the sub or supergroups, you must make the
+relevant change in both groups and both files to make sure there are no discrepancies between the groups.
+
+To make sure that your changes were correct, run the data linting test in the
+[data_lint_spec.rb](../spec/data_lint_spec.rb) file. 

--- a/data/supergroups.yml
+++ b/data/supergroups.yml
@@ -1,0 +1,49 @@
+content_purpose_supergroup:
+  name: "Content Purpose Supergroup"
+  description: "These are the new supergroups that came out of the research from the JTBD framework in Q4 by the navigation team and are used in the topic pages."
+  default: other
+  items:
+    - id: news_and_communications
+      subgroups:
+        - updates_and_alerts
+        - news
+        - speeches_and_statements
+    - id: guidance_and_regulation
+      subgroups:
+        - guidance
+        - regulation
+        - business_support
+    - id: services
+      subgroups:
+        - transactions
+    - id: policy_and_engagement
+      subgroups:
+        - policy
+        - consultations
+    - id: transparency
+      subgroups:
+        - decisions
+        - incidents
+        - research_and_data
+
+documentation : |
+  ##Content Purpose Supergroups
+
+  These are the grouping that the navigation team came up with
+  as a result of an investigation done using the "Jobs to be Done" framework in Q4.
+
+  There are 5 high level Content Purpose Supergroups which each group together some subgroups
+  which in turn group `document_types`.
+
+  More information about the JTBD framework and the supergroups can be found on the
+  [GovUK wiki](https://gov-uk.atlassian.net/wiki/spaces/GFED/pages/305201156/Document+type+groupings)
+
+  The list of which document types are grouped by both supergroups and subgroups can be
+  found in the [supertypes.yml](./supertypes.yml) file.
+
+  The list of the subgroups grouped by supergroup are in the file [supergroups.yml](./supergroups.yml).
+  If you want to make a change to the `document_type` groupings in the sub or supergroups, you must make the
+  relevant change in both groups and both files to make sure there are no discrepancies between the groups.
+
+  To make sure that your changes were correct, run the data linting test in the
+  [data_lint_spec.rb](../spec/data_lint_spec.rb) file.

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -27,7 +27,7 @@ navigation_document_supertype:
 
 content_purpose_document_supertype:
   name: "Content purpose"
-  description: "As defined by the Frontend & Navigation team in Q3-2017. The team grouped document types that serve a similar purpose for users into top-level content groups. In time, this information could be used to serve relevant links into a content page sidebar and pull feeds of specific content groups into navigation pages."
+  description: "DEPRECATED - Please use `content_purpose_subgroup`. The team grouped document types that serve a similar purpose for users into top-level content groups. In time, this information could be used to serve relevant links into a content page sidebar and pull feeds of specific content groups into navigation pages."
   default: other
   items:
     - id: updates-and-alerts
@@ -40,7 +40,6 @@ content_purpose_document_supertype:
         - official_statistics_announcement
         - staff_update
         - statistics_announcement
-        - vehicle_recalls_and_faults_alert
 
     - id: news
       description: To communicate what government is doing (non-urgent)
@@ -381,3 +380,192 @@ government_document_supertype:
     - id: government-responses
       document_types:
         - government_response
+
+content_purpose_subgroup:
+  name: "Content Purpose Subgroup"
+  description: "These are the new sub groups that came out of the research from the JTBD framework in Q4 by the navigation team and are used in the topic pages. These are the sub groups connected to the content_purpose_document_supergroup"
+  default: other
+  items:
+    - id: updates_and_alerts
+      document_types:
+        - fatality_notice
+        - medical_safety_alert
+        - drug_safety_update
+        - notice
+    - id: news
+      document_types:
+        - news_article
+        - news_story
+        - press_release
+        - world_location_news_article
+        - world_news_story
+    - id: speeches_and_statements
+      document_types:
+        - speech
+        - oral_statement
+        - written_statement
+        - authored_article
+        - government_response
+        - correspondence
+    - id: guidance
+      document_types:
+        - guide
+        - detailed_guide
+        - manual
+        - manual_section
+        - guidance
+        - answer
+        - contact
+        - calendar
+        - travel_advice
+    - id: regulation
+      document_types:
+        - statutory_guidance
+        - regulation
+    - id: business_support
+      document_types:
+        - international_development_fund
+        - countryside_stewardship_grant
+        - esi_fund
+        - business_finance_support_scheme
+    - id: transactions
+      document_types:
+        - transaction
+        - completed_transaction
+        - local_transaction
+        - form
+        - licence
+        - calculator
+        - smart_answer
+        - simple_smart_answer
+        - place
+        - step_by_step_nav
+    - id: policy
+      document_types:
+        - policy_paper
+        - independent_report
+        - impact_assessment
+        - case_study
+    - id: consultations
+      document_types:
+        - open_consultation
+        - closed_consultation
+        - consultation_outcome
+    - id: decisions
+      document_types:
+        - decision
+        - employment_tribunal_decision
+        - tax_tribunal_decision
+        - utaac_decision
+        - asylum_support_decision
+        - employment_appeal_tribunal_decision
+        - international_treaty
+        - service_standard_report
+        - cma_case
+    - id: incidents
+      document_types:
+        - aaib_report
+        - raib_report
+        - maib_report
+    - id: research_and_data
+      document_types:
+        - official_statistics
+        - statistics
+        - national_statistics
+        - statistics_announcement
+        - national_statistics_announcement
+        - official_statistics_announcement
+        - statistical_data_set
+        - research
+        - dfid_research_output
+        - transparency
+        - map
+        - foi_release
+
+content_purpose_supergroup:
+  name: "Content Purpose Supergroup"
+  description: "These are the new supergroups that came out of the research from the JTBD framework in Q4 by the navigation team and are used in the topic pages."
+  default: other
+  items:
+    - id: news_and_communications
+      document_types:
+        - fatality_notice
+        - medical_safety_alert
+        - drug_safety_update
+        - notice
+        - news_article
+        - news_story
+        - press_release
+        - world_location_news_article
+        - world_news_story
+        - speech
+        - oral_statement
+        - written_statement
+        - authored_article
+        - government_response
+        - correspondence
+    - id: guidance_and_regulation
+      document_types:
+        - guide
+        - detailed_guide
+        - manual
+        - manual_section
+        - guidance
+        - answer
+        - contact
+        - calendar
+        - travel_advice
+        - statutory_guidance
+        - regulation
+        - international_development_fund
+        - countryside_stewardship_grant
+        - esi_fund
+        - business_finance_support_scheme
+    - id: services
+      document_types:
+        - transaction
+        - completed_transaction
+        - local_transaction
+        - form
+        - licence
+        - calculator
+        - smart_answer
+        - simple_smart_answer
+        - place
+        - step_by_step_nav
+    - id: policy_and_engagement
+      document_types:
+        - policy_paper
+        - independent_report
+        - impact_assessment
+        - case_study
+        - open_consultation
+        - closed_consultation
+        - consultation_outcome
+    - id: transparency
+      document_types:
+        - decision
+        - employment_tribunal_decision
+        - tax_tribunal_decision
+        - utaac_decision
+        - asylum_support_decision
+        - employment_appeal_tribunal_decision
+        - international_treaty
+        - service_standard_report
+        - cma_case
+        - aaib_report
+        - raib_report
+        - maib_report
+        - official_statistics
+        - statistics
+        - national_statistics
+        - statistics_announcement
+        - national_statistics_announcement
+        - official_statistics_announcement
+        - statistical_data_set
+        - research
+        - dfid_research_output
+        - transparency
+        - map
+        - foi_release
+


### PR DESCRIPTION
As part of building the navigation topic pages we did work using the
JTBD framework to identify new content purpose sub and supergroups.
In order to help users find the content they require, we can group
document types by the needs they're designed to meet and the purpose of
the content.
See the wiki for more info:
https://gov-uk.atlassian.net/wiki/spaces/GFED/pages/305201156/Document+type+groupings

Due to the fact that the content purpose supergroups group subgroups not
document types, we have added a new yaml file for the supergroups.

The data lint specs have been change to test both data files.