### PR TITLE
Change supergroup documentation in yaml file.

### DIFF
--- a/data/supergroups.yml
+++ b/data/supergroups.yml
@@ -27,23 +27,21 @@ content_purpose_supergroup:
         - research_and_data
 
 documentation : |
-  ##Content Purpose Supergroups
-
   These are the grouping that the navigation team came up with
   as a result of an investigation done using the "Jobs to be Done" framework in Q4.
 
-  There are 5 high level Content Purpose Supergroups which each group together some subgroups
-  which in turn group `document_types`.
+  There are 5 high level Content Purpose Supergroups which each group together some Content Purpose Subgroups.
 
   More information about the JTBD framework and the supergroups can be found on the
   [GovUK wiki](https://gov-uk.atlassian.net/wiki/spaces/GFED/pages/305201156/Document+type+groupings)
 
   The list of which document types are grouped by both supergroups and subgroups can be
-  found in the [supertypes.yml](./supertypes.yml) file.
+  found in the [supertypes.yml](https://github.com/alphagov/govuk_document_types/blob/master/data/supertypes.yml) file.
 
-  The list of the subgroups grouped by supergroup are in the file [supergroups.yml](./supergroups.yml).
+  The list of the subgroups grouped by supergroup are in the file
+  [supergroups.yml](https://github.com/alphagov/govuk_document_types/blob/master/data/supergroups.yml).
   If you want to make a change to the `document_type` groupings in the sub or supergroups, you must make the
   relevant change in both groups and both files to make sure there are no discrepancies between the groups.
 
-  To make sure that your changes were correct, run the data linting test in the
-  [data_lint_spec.rb](../spec/data_lint_spec.rb) file.
+  To make sure that your changes were correct, run the data linting tests in
+  [data_lint_spec.rb](https://github.com/alphagov/govuk_document_types/blob/master/spec/data_lint_spec.rb).


### PR DESCRIPTION
This documentation will be imported into and used in the developer docs
so I needed to change some of the links and the markdown syntax for the
HTML to display correctly.

This documentation will appear on the Content purpose supergroup page in
the documentation. https://docs.publishing.service.gov.uk/document-types/content_purpose_supergroup.html

https://trello.com/c/7xgGx4aM/86-add-contentpurposesubgroup-and-contentpurposesupergroup-to-developer-docs