### PR TITLE
Expose the content purpose super and sub groups data

### DIFF
--- a/lib/govuk_document_types.rb
+++ b/lib/govuk_document_types.rb
@@ -3,6 +3,7 @@ require "yaml"
 
 module GovukDocumentTypes
   DATA = YAML.load_file(File.dirname(__FILE__) + "/../data/supertypes.yml")
+  SUPERGROUPS = YAML.load_file(File.dirname(__FILE__) + "/../data/supergroups.yml")
 
   def self.supertypes(document_type:)
     types = {}
@@ -17,5 +18,10 @@ module GovukDocumentTypes
     end
 
     types
+  end
+
+  def self.supergroups(ids:)
+    groups = SUPERGROUPS["content_purpose_supergroup"]["items"]
+    groups.select { |g| ids.include?(g["id"]) }
   end
 end

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -18,4 +18,13 @@ describe GovukDocumentTypes do
       expect(supertypes).to include("navigation_document_supertype" => "other")
     end
   end
+
+  describe '.supergroup' do
+    it 'returns supergroups with matching ids' do
+      ids = %w(news_and_communications services)
+      supergroups = GovukDocumentTypes.supergroups(ids: ids)
+
+      expect(supergroups.map { |g| g["id"] }).to eq(ids)
+    end
+  end
 end


### PR DESCRIPTION
Part of https://trello.com/c/SRSswLXj/116-create-a-production-ready-v1-of-the-list-page-finders

The `content_purpose_supergroup` and `content_purpose_subgroup`
data will be used by finder-frontend for building dynamic
filtering facets. So add a convenient way to expose this data.