### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.0
+
+* Adds `GovukDocumentTypes.supergroups(:ids)` as a way to retrieve
+  supergroups by ID.
+
 # 0.3.0
 
 * Add `content_purpose_supergroup` and `content_purpose_subgroup`

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "0.3.0".freeze
+  VERSION = "0.4.0".freeze
 end


### PR DESCRIPTION
Part of https://trello.com/c/aKKX4OIo/117-build-version-of-a-finder-which-can-link-to-topic-pages-based-on-revised-designs

* Adds `GovukDocumentTypes.supergroups(:ids)` as a way to retrieve supergroups by ID.