### PR TITLE
Remove navigation_document_supertype

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -1,30 +1,3 @@
-navigation_document_supertype:
-  name: "Navigation document type"
-  description: "Used to filter pages on the new taxonomy-based navigation pages"
-  default: other
-  items:
-    - id: guidance
-      document_types:
-        - answer
-        - contact
-        - detailed_guide
-        - document_collection
-        - form
-        - guidance
-        - guide
-        - licence
-        - local_transaction
-        - manual
-        - map
-        - place
-        - promotional
-        - regulation
-        - simple_smart_answer
-        - smart_answer
-        - statutory_guidance
-        - transaction
-        - travel_advice
-
 user_journey_document_supertype:
   name: "User journey"
   description: "Used to distinguish pages used mainly for navigation (finding) from content pages (thing)"

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -7,15 +7,15 @@ describe GovukDocumentTypes do
 
   describe '.supertypes' do
     it 'returns a supertype for a known document type' do
-      supertypes = GovukDocumentTypes.supertypes(document_type: 'detailed_guide')
+      supertypes = GovukDocumentTypes.supertypes(document_type: "open_consultation")
 
-      expect(supertypes).to include("navigation_document_supertype" => "guidance")
+      expect(supertypes).to include("government_document_supertype" => "consultations")
     end
 
     it 'returns the default supertype for an unknown document type' do
       supertypes = GovukDocumentTypes.supertypes(document_type: 'something_not_there')
 
-      expect(supertypes).to include("navigation_document_supertype" => "other")
+      expect(supertypes).to include("government_document_supertype" => "other")
     end
   end
 


### PR DESCRIPTION
This supertype is no longer used and has been superseded by https://docs.publishing.service.gov.uk/document-types/content_purpose_subgroup.html.

https://trello.com/c/6wRHXCyT