### PR TITLE
Remove search_user_need_document_supertype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Removes `content_purpose_document_supertype`
+* Removes `search_user_need_document_supertype`
 
 # 0.4.0
 

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -49,23 +49,6 @@ user_journey_document_supertype:
         - topic
         - topical_event
 
-search_user_need_document_supertype:
-  name: "Search user need"
-  description: "Used to group documents based on user need, core for mainstream users and government for specialist users in search results"
-  default: government
-  items:
-    - id: core
-      document_types:
-        - answer
-        - guide
-        - local_transaction
-        - place
-        - simple_smart_answer
-        - smart_answer
-        - transaction
-        - travel_advice
-        - travel_advice_index
-
 email_document_supertype:
   name: "Email document type"
   description: "High level group for email subscriptions use to identify publications and announcement"


### PR DESCRIPTION
This supertype is only used in search. We'll replace it there with something simpler.

https://trello.com/c/6wRHXCyT