### PR TITLE
Version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.7.0
+
+* Move `decisions` `content_purpose_subgroup` from `transparency` to `news_and_communications`
+* Add new `research_and_statistics` `content_purpose_supergroup`
+* Splits `transparency` `content_purpose_supergroup` into `incidents`, `freedom_of_information_releases`, and `transparency_data`
+* Move some document types around between `content_purpose_subgroups`
+
 # 0.6.0
 
 * Adds `corporate_report` document type to `content_purpose_subgroup`

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "0.6.0".freeze
+  VERSION = "0.7.0".freeze
 end


### PR DESCRIPTION
Implements Version 2.2 of the supergroups. Includes the following changes:
* Move `decisions content_purpose_subgroup` from `transparency` to `news_and_communications`
* Add new `research_and_statistics content_purpose_supergroup`
* Splits `transparency content_purpose_supergroup` into `incidents`, `freedom_of_information_releases`, and `transparency_data`
* Move some document types around between `content_purpose_subgroups`

Full details of changes available in this spreadsheet: https://docs.google.com/spreadsheets/d/1n9OJ4s7AOd5-JDOz_gXgWLdLGxzzzJUxnc-bJXOyQQ0/edit#gid=1065921575