### PR TITLE
[DO NOT MERGE] Allow iteration of content purpose supergroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Configure display names for content_purpose supertypes
+
 # 0.7.1
 
 * Add `hrmc_manual` format to `guidance` `content_purpose_subgroup`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Configure display names for content_purpose supertypes
+* Lookup of document types that belong to a group within a supertype
 
 # 0.7.1
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ of document types.
 
 https://docs.publishing.service.gov.uk/document-types.html
 
-This gem is only to be used in [publishing-api][publishing-api] and
-[rummager][rummager]. **Don't use it in your project**.
-
 ## Long term vision
 
-This gem is used to share the canonical list of supertypes between rummager and publishing-api. We're currently migrating to a new system of indexing where rummager gets all data from the publishing-api (via a message queue). Once that work is completed this repo should be retired and the canonical list should be moved to either [govuk-content-schemas][] for use in the publishing-api, or be moved into publishing-api directly.
+This gem is used to share the canonical list of supertypes between applications on
+GOV.UK. This used to be limited to publishing-api and rummager, but has now been
+expanded to allow other applications.  We found that relying on republishing affected
+content after any changes wasn't flexible enough to permit iteration of groups, or
+allowing other configuration of supertypes (such as display names) to be used.
 
 ## How to add a supertype
 

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -382,6 +382,8 @@ government_document_supertype:
         - government_response
 
 content_purpose_subgroup:
+  # This supertype is being iterated. Content items and search results may be out of date
+  # Speak to the content pages team for more information
   name: "Content Purpose Subgroup"
   description: "These are the new sub groups that came out of the research from the JTBD framework in Q4 by the navigation team and are used in the topic pages. These are the sub groups connected to the content_purpose_document_supergroup"
   default: other
@@ -508,6 +510,8 @@ content_purpose_subgroup:
         - maib_report
 
 content_purpose_supergroup:
+  # This supertype is being iterated. Content items and search results may be out of date
+  # Speak to the content pages team for more information
   name: "Content Purpose Supergroup"
   description: "These are the new supergroups that came out of the research from the JTBD framework in Q4 by the navigation team and are used in the topic pages."
   default: other

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -387,10 +387,12 @@ content_purpose_subgroup:
   default: other
   items:
     - id: updates_and_alerts
+      display_name: Safety alerts
       document_types:
         - medical_safety_alert
         - drug_safety_update
     - id: news
+      display_name: Announcements
       document_types:
         - news_article
         - news_story
@@ -399,6 +401,7 @@ content_purpose_subgroup:
         - world_news_story
         - fatality_notice
     - id: decisions
+      display_name: Decisions
       document_types:
         - tax_tribunal_decision
         - utaac_decision
@@ -409,6 +412,7 @@ content_purpose_subgroup:
         - cma_case
         - decision
     - id: speeches_and_statements
+      display_name: Speeches and statements
       document_types:
         - oral_statement
         - written_statement
@@ -417,6 +421,7 @@ content_purpose_subgroup:
         - speech
         - government_response
     - id: transactions
+      display_name: Services
       document_types:
         - completed_transaction
         - local_transaction
@@ -431,10 +436,12 @@ content_purpose_subgroup:
         - answer
         - guide
     - id: regulation
+      display_name: Regulation
       document_types:
         - regulation
         - statutory_instrument
     - id: guidance
+      display_name: Guidance
       document_types:
         - detailed_guide
         - manual
@@ -450,27 +457,32 @@ content_purpose_subgroup:
         - promotional
         - hmrc_manual
     - id: business_support
+      display_name: Business funds and grants
       document_types:
         - international_development_fund
         - countryside_stewardship_grant
         - esi_fund
         - business_finance_support_scheme
     - id: policy
+      display_name: Policy papers
       document_types:
         - impact_assessment
         - case_study
         - policy_paper
     - id: consultations
+      display_name: Consultations
       document_types:
         - open_consultation
         - closed_consultation
         - consultation_outcome
     - id: research
+      display_name: Research
       document_types:
         - dfid_research_output
         - independent_report
         - research
     - id: statistics
+      display_name: Statistics
       document_types:
         - statistics
         - national_statistics
@@ -480,13 +492,16 @@ content_purpose_subgroup:
         - statistical_data_set
         - official_statistics
     - id: transparency_data
+      display_name: Transparency data
       document_types:
         - transparency
         - corporate_report
     - id: freedom_of_information_releases
+      display_name: Freedom of information releases
       document_types:
         - foi_release
     - id: incidents
+      display_name: Incident reports
       document_types:
         - aaib_report
         - raib_report
@@ -498,6 +513,7 @@ content_purpose_supergroup:
   default: other
   items:
     - id: news_and_communications
+      display_name: News and communications
       document_types:
         - medical_safety_alert
         - drug_safety_update
@@ -522,6 +538,7 @@ content_purpose_supergroup:
         - speech
         - government_response
     - id: services
+      display_name: Services
       document_types:
         - completed_transaction
         - local_transaction
@@ -536,6 +553,7 @@ content_purpose_supergroup:
         - answer
         - guide
     - id: guidance_and_regulation
+      display_name: Guidance and regulation
       document_types:
         - regulation
         - detailed_guide
@@ -557,6 +575,7 @@ content_purpose_supergroup:
         - statutory_instrument
         - hmrc_manual
     - id: policy_and_engagement
+      display_name: Policy papers and consultations
       document_types:
         - impact_assessment
         - case_study
@@ -565,6 +584,7 @@ content_purpose_supergroup:
         - closed_consultation
         - consultation_outcome
     - id: research_and_statistics
+      display_name: Research and statistics
       document_types:
         - dfid_research_output
         - independent_report
@@ -577,6 +597,7 @@ content_purpose_supergroup:
         - statistical_data_set
         - official_statistics
     - id: transparency
+      display_name: Transparency and freedom of information releases
       document_types:
         - transparency
         - corporate_report

--- a/lib/govuk_document_types.rb
+++ b/lib/govuk_document_types.rb
@@ -24,4 +24,17 @@ module GovukDocumentTypes
     groups = SUPERGROUPS["content_purpose_supergroup"]["items"]
     groups.select { |g| ids.include?(g["id"]) }
   end
+
+  def self.display_name(supertype:, group:)
+    supertype_group(supertype: supertype, group: group)["display_name"]
+  end
+
+  def self.document_types(supertype:, group:)
+    supertype_group(supertype: supertype, group: group)["document_types"]
+  end
+
+  private_class_method def self.supertype_group(supertype:, group:)
+    supertype_groups = DATA[supertype]["items"]
+    supertype_groups.detect { |item| item["id"] == group }
+  end
 end

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -45,4 +45,28 @@ describe GovukDocumentTypes do
       expect(nil).to eq(name)
     end
   end
+
+  describe '.document_types' do
+    it 'returns document types that belong to a group within a supertype' do
+      supertype = "content_purpose_supergroup"
+      group = "services"
+
+      document_types = GovukDocumentTypes.document_types(supertype: supertype, group: group)
+
+      expect(document_types).to eq(
+        %w(completed_transaction
+           local_transaction
+           form
+           calculator
+           smart_answer
+           simple_smart_answer
+           place
+           licence
+           step_by_step_nav
+           transaction
+           answer
+           guide)
+          )
+    end
+  end
 end

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -27,4 +27,22 @@ describe GovukDocumentTypes do
       expect(supergroups.map { |g| g["id"] }).to eq(ids)
     end
   end
+
+  describe '.display_name' do
+    it 'returns a configured display name' do
+      supertype = "content_purpose_supergroup"
+      group = "policy_and_engagement"
+
+      name = GovukDocumentTypes.display_name(supertype: supertype, group: group)
+      expect("Policy papers and consultations").to eq(name)
+    end
+
+    it 'returns nil if the display name is not configured' do
+      supertype = "content_purpose_document_supertype"
+      group = "updates-and-alerts"
+
+      name = GovukDocumentTypes.display_name(supertype: supertype, group: group)
+      expect(nil).to eq(name)
+    end
+  end
 end


### PR DESCRIPTION
This PR has a couple of bits in it which allow us to use supertypes more easily from other applications.  The change of approach from limiting this to publishing-api and rummager was agreed with the other GOV.UK teams on Monday 17th.

## Allow display names for supertype groups

The ID of content purpose supertypes is coupled to the UI and [URL schemes](https://www.gov.uk/search/advanced?group=services&topic=%2Feducation) in finder-frontend and collections.

We want to rename several groups, but don't want to change the ID unless it's absolutely necessary.  Having an optional display name allows us to override this when we need to and keep it in sync across apps.

## Find document_types in a supertype group

We want to decouple content_purpose supertypes from having to be indexed prior to being useful, as we want to be able to iterate them easily.  Republishing content is time consuming and can cause a backlog of "real" changes.

The content purpose types are mostly used in applications that use filter_content_purpose_supergroup type queries to rummager to return the required content.  To remove the requirement for rummager to be up to date, we'll allow applications to resolve
a list of document types that belong to a supertype.  They can then generate queries using `filter_content_store_document_type` and the list of document types.

https://trello.com/c/meFnwXAy/171-rollout-supergroup-v22-renaming-new