### PR TITLE
Version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.8.0
+
+* Adds `GovukDocumentTypes.supergroup_subgroups` as a way to retrieve
+  subgroups registered to the specified supergroups.
+* Adds `GovukDocumentTypes.supergroup_document_types` as a way to retrieve
+  document types registered to the specified supergroups.
+* Adds `GovukDocumentTypes.subgroup_document_types` as a way to retrieve
+  document types registered to the specified subgroups.
+
 # 0.7.1
 
 * Add `hrmc_manual` format to `guidance` `content_purpose_subgroup`

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "0.7.1".freeze
+  VERSION = "0.8.0".freeze
 end


### PR DESCRIPTION
- Adds `GovukDocumentTypes.supergroup_subgroups` as a way to retrieve  subgroups registered to the specified supergroups.

- Adds `GovukDocumentTypes.supergroup_document_types` as a way to retrieve  document types registered to the specified supergroups.

- Adds `GovukDocumentTypes.subgroup_document_types` as a way to retrieve  document types registered to the specified subgroups.