### PR TITLE
Add translations to content_purpose supertypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add translations to content purpose supergroup titles
+
 # 0.8.0
 
 * Adds `GovukDocumentTypes.supergroup_subgroups` as a way to retrieve

--- a/govuk_document_types.gemspec
+++ b/govuk_document_types.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "govuk-lint", "~> 3.0"
+  spec.add_development_dependency "i18n-spec"
 end

--- a/lib/govuk_document_types.rb
+++ b/lib/govuk_document_types.rb
@@ -1,3 +1,4 @@
+require "govuk_document_types/translations_railtie" if defined?(Rails)
 require "govuk_document_types/version"
 require "yaml"
 

--- a/lib/govuk_document_types/translations_railtie.rb
+++ b/lib/govuk_document_types/translations_railtie.rb
@@ -1,0 +1,21 @@
+require 'rails'
+module GovukDocumentTypes
+  class TranslationsRailtie < ::Rails::Railtie
+    initializer 'govuk_document_types' do |app|
+      GovukDocumentTypes::TranslationsRailtie.instance_eval do
+        pattern = pattern_from app.config.i18n.available_locales
+        add("rails/locale/#{pattern}.yml")
+      end
+    end
+
+    def self.add(pattern)
+      files = Dir[File.join(File.dirname(__FILE__), '../..', pattern)]
+      I18n.load_path.concat(files)
+    end
+
+    def self.pattern_from(args)
+      array = Array(args || [])
+      array.blank? ? '*' : "{#{array.join ','}}"
+    end
+  end
+end

--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -1,0 +1,28 @@
+---
+en:
+  content_purpose_supergroup:
+    guidance_and_regulation: Guidance and regulation
+    news_and_communications: News and communications
+    policy_and_engagement: Policy papers and consultations
+    research_and_statistics: "Research and statistics"
+    services: Services
+    transparency: Transparency and freedom of information releases
+  content_purpose_subgroup:
+    announcements: Announcements
+    business_support: Business funds and grants
+    consultations: Consultations
+    decisions: Decisions
+    freedom_of_information_releases: Freedom of information releases
+    guidance: Guidance
+    incidents: Incident reports
+    news: News
+    policy: Policy papers
+    regulation: Regulation
+    research: Research
+    safety_alerts: Safety alerts
+    services: Services
+    speeches_and_statements: Speeches and statements
+    statistics: Statistics
+    transactions: Transactions
+    transparency_data: Transparency data
+    updates_and_alerts: Updates and alerts

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "govuk_document_types"
+require "i18n-spec"

--- a/spec/translations_spec.rb
+++ b/spec/translations_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe "A locale file" do
+  Dir.glob('rails/locale/*.yml') do |locale_file|
+    it_behaves_like 'a valid locale file', locale_file
+  end
+end
+
+describe "Translations of supertype group titles" do
+  Dir.glob('rails/locale/*.yml') do |locale_file|
+    translations = YAML.load_file(locale_file)
+
+    %w(content_purpose_supergroup content_purpose_subgroup).each do |supertype|
+      context "The #{supertype} supertype in #{locale_file}" do
+        group_ids = GovukDocumentTypes::SUPERTYPES[supertype]["items"].map { |item| item["id"] }
+
+        group_ids.each do |group_id|
+          it "has a title for the #{group_id} group" do
+            group_title_translation = translations["en"][supertype][group_id]
+            expect(group_title_translation).to_not be(nil), "Couldn't find translation for #{supertype}.#{group_id}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to be able to trivially change the title of a supertype and keep it consistent between applications.  The initial purpose is to change "Policy and engagement" to "Policy papers and consultations".

We've also added translations for some subgroups that don't exist yet - they'll be added next.

[Supertypes v2.2](https://docs.google.com/spreadsheets/d/1n9OJ4s7AOd5-JDOz_gXgWLdLGxzzzJUxnc-bJXOyQQ0/edit#gid=1065921575)

https://trello.com/c/Q88UJzp5/177-update-collections-to-use-the-govukdocumenttypes-gem