### PR TITLE
Remove 'contact' document type from 'guidance and regulation' supergroup

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -539,7 +539,6 @@ content_purpose_supergroup:
         - manual_section
         - guidance
         - map
-        - contact
         - calendar
         - statutory_guidance
         - notice


### PR DESCRIPTION
## What

We want to remove the doc type `contact` from `guidance_and_regulation` under `content_purpose_supergroup`.

## Why

Contact pages aren't guidance! They're appearing under guidance in finders and on org pages, which is resulting in users making calls to call centres instead of reading the guidance that might actually provide them with the information they need _not_ to call.