### PR TITLE
Remove 'contact' from 'guidance and regulation'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Removed `contact` from the guidance group.
+
 # 0.9.0
 
 * Add translations to content purpose supergroup titles

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -437,7 +437,6 @@ content_purpose_subgroup:
         - manual_section
         - guidance
         - map
-        - contact
         - calendar
         - statutory_guidance
         - notice
@@ -539,7 +538,6 @@ content_purpose_supergroup:
         - manual_section
         - guidance
         - map
-        - contact
         - calendar
         - statutory_guidance
         - notice


### PR DESCRIPTION
Stolen from @sistephens

## What

We want to remove the doc type `contact` from `guidance_and_regulation` under `content_purpose_supergroup`.

## Why

Contact pages aren't guidance! They're appearing under guidance in finders and on org pages, which is resulting in users making calls to call centres instead of reading the guidance that might actually provide them with the information they need _not_ to call.

For some reason https://github.com/alphagov/govuk_document_types/pull/63 isn't taking updates, so I've opened a new PR.