### PR TITLE
Move case studies to news and communications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Moved `case_study` from policy papers and consultations to news and comms.
+
 # 0.9.1
 
 * Removed `contact` from the guidance group.

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -388,6 +388,7 @@ content_purpose_subgroup:
         - drug_safety_update
     - id: news
       document_types:
+        - case_study
         - news_article
         - news_story
         - press_release
@@ -453,7 +454,6 @@ content_purpose_subgroup:
     - id: policy
       document_types:
         - impact_assessment
-        - case_study
         - policy_paper
     - id: consultations
       document_types:
@@ -516,6 +516,7 @@ content_purpose_supergroup:
         - correspondence
         - speech
         - government_response
+        - case_study
     - id: services
       document_types:
         - completed_transaction
@@ -553,7 +554,6 @@ content_purpose_supergroup:
     - id: policy_and_engagement
       document_types:
         - impact_assessment
-        - case_study
         - policy_paper
         - open_consultation
         - closed_consultation

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -58,7 +58,6 @@ describe GovukDocumentTypes do
 
       expect(document_types)
         .to contain_exactly(
-          'case_study',
           'dfid_research_output',
           'impact_assessment',
           'independent_report',


### PR DESCRIPTION
After a slack discussion with Lucy Hartley, Si Stephens and others in response
to this [zendesk ticket](https://govuk.zendesk.com/agent/tickets/3729027), it
was agreed that policy papers and consultations was not the correct location
for case studies to live.

https://trello.com/c/m5wd2ujS/841-fix-case-studies-supergroup-allocation