### PR TITLE
Add 'standard' to guidance and regulation supergroup

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -445,6 +445,7 @@ content_purpose_subgroup:
         - travel_advice
         - promotional
         - hmrc_manual
+        - standard
     - id: business_support
       document_types:
         - international_development_fund
@@ -551,6 +552,7 @@ content_purpose_supergroup:
         - business_finance_support_scheme
         - statutory_instrument
         - hmrc_manual
+        - standard
     - id: policy_and_engagement
       document_types:
         - impact_assessment


### PR DESCRIPTION
This will allow us to include standards in the [Guidance and Regulation Finder](https://www.gov.uk/search/guidance-and-regulation).

Trello card: https://trello.com/c/ugeapNY0