### PR TITLE
Add FCERM Research Report to research supergroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 * Remove deprecated supertypes
-
+* Add Flood & Coastal Erosion Risk Management Report (FCERM) Research Report to research supergroup
+    
 # 0.9.3
 
 * Added `standard` subtype to the guidance group

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -237,6 +237,7 @@ content_purpose_subgroup:
     - id: research
       document_types:
         - dfid_research_output
+        - flood_and_coastal_erosion_risk_management_research_report
         - independent_report
         - research
     - id: statistics
@@ -336,6 +337,7 @@ content_purpose_supergroup:
     - id: research_and_statistics
       document_types:
         - dfid_research_output
+        - flood_and_coastal_erosion_risk_management_research_report
         - independent_report
         - research
         - statistics

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -59,6 +59,7 @@ describe GovukDocumentTypes do
       expect(document_types)
         .to contain_exactly(
           'dfid_research_output',
+          'flood_and_coastal_erosion_risk_management_research_report',
           'impact_assessment',
           'independent_report',
           'policy_paper',


### PR DESCRIPTION
FCERM = Flood & Coastal Erosion Risk Management Report

This will allow these reports to appear in the 'Latest from' section on the Flood and Coastal Erosion Risk Management Research and Development Programme organisation page.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4526682