### PR TITLE
Release version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# Unreleased
+# 1.0.0
 
 * Remove deprecated supertypes
 * Add Flood & Coastal Erosion Risk Management Report (FCERM) Research Report to research supergroup
-    
+
 # 0.9.3
 
 * Added `standard` subtype to the guidance group

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "0.9.3".freeze
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
Includes:

* Remove deprecated supertypes
* Add Flood & Coastal Erosion Risk Management Report (FCERM) Research Report to research supergroup

The removal of the old types is a breaking change (if they're used), though we're pretty confident that they aren't used anywhere.

Releasing v1 as we've used this gem for ages, and it's been stable for a long time.