### PR TITLE
Remove FCERM Research Report from research supergroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove Flood & Coastal Erosion Risk Management Report (FCERM) Research Report from research supergroup
+
 # 1.0.0
 
 * Remove deprecated supertypes

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -237,7 +237,6 @@ content_purpose_subgroup:
     - id: research
       document_types:
         - dfid_research_output
-        - flood_and_coastal_erosion_risk_management_research_report
         - independent_report
         - research
     - id: statistics
@@ -337,7 +336,6 @@ content_purpose_supergroup:
     - id: research_and_statistics
       document_types:
         - dfid_research_output
-        - flood_and_coastal_erosion_risk_management_research_report
         - independent_report
         - research
         - statistics

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -59,7 +59,6 @@ describe GovukDocumentTypes do
       expect(document_types)
         .to contain_exactly(
           'dfid_research_output',
-          'flood_and_coastal_erosion_risk_management_research_report',
           'impact_assessment',
           'independent_report',
           'policy_paper',


### PR DESCRIPTION
Reverts previous PR #72 so that the reports don't appear in the 'Latest from' section on the Flood and Coastal Erosion Risk Management Research and Development Programme organisation page.

Zendesk: https://govuk.zendesk.com/agent/tickets/4526682