### PR TITLE
Add govuk_content_schemas as development dependency

### DIFF
--- a/govuk_document_types.gemspec
+++ b/govuk_document_types.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
+  spec.add_development_dependency "govuk_schemas", ">= 4.5.0"
   spec.add_development_dependency "i18n-spec"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/data_lint_spec.rb
+++ b/spec/data_lint_spec.rb
@@ -33,16 +33,13 @@ describe "Data lint" do
     end
 
     it "contains only valid document types" do
-      schema_directory = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../govuk-content-schemas"
-      allowed_document_types = YAML.load_file("#{schema_directory}/lib/govuk_content_schemas/allowed_document_types.yml")
-
       document_types = GovukDocumentTypes::SUPERTYPES.flat_map do |_name, definition|
         definition["items"].flat_map do |supertype|
           supertype["document_types"]
         end
       end
 
-      expect(document_types - allowed_document_types).to eql([])
+      expect(document_types - GovukSchemas::DocumentTypes.valid_document_types).to eql([])
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "govuk_document_types"
+require "govuk_schemas"
 require "i18n-spec"


### PR DESCRIPTION
This added support for content schemas in publishing api, as these have recently been moved. Using this means we can stop hardcoding the path to allowed_document_types in tests.

This fixes a problem with the most recent builds: [example](https://github.com/alphagov/govuk_document_types/actions/runs/3591475089). This is failing because the file 'allowed_document_types' has moved to a new location within publishing api, relative to its old location in govuk-content-schemas. We were previously supporting this old location with a symlink, but this [has recently been removed](https://github.com/alphagov/publishing-api/commit/f2b25a1116ac6c4cdbb2b32904b9eb5ae4d4c8c0) since the govuk_schemas gem has been updated to point to the correct place.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)