### PR TITLE
Added new call for evidence document type to supertypes and group

### DIFF
--- a/data/supergroups.yml
+++ b/data/supergroups.yml
@@ -21,6 +21,7 @@ content_purpose_supergroup:
       subgroups:
         - policy
         - consultations
+        - calls_for_evidence
     - id: research_and_statistics
       subgroups:
         - research

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -27,6 +27,9 @@ email_document_supertype:
   items:
     - id: "publications"
       document_types:
+        - call_for_evidence
+        - call_for_evidence_outcome
+        - closed_call_for_evidence
         - closed_consultation
         - consultation
         - consultation_outcome
@@ -43,6 +46,7 @@ email_document_supertype:
         - national_statistics
         - notice
         - official_statistics
+        - open_call_for_evidence
         - open_consultation
         - policy_paper
         - promotional
@@ -69,6 +73,12 @@ government_document_supertype:
   # we expect that everything should be mapped to a valid supertype.
   default: other
   items:
+    - id: calls-for-evidence
+      document_types:
+        - call_for_evidence
+        - open_call_for_evidence
+        - call_for_evidence_outcome
+        - closed_call_for_evidence
     - id: consultations
       document_types:
         - consultation
@@ -256,6 +266,11 @@ content_purpose_subgroup:
         - aaib_report
         - raib_report
         - maib_report
+    - id: calls_for_evidence
+      document_types:
+        - open_call_for_evidence
+        - closed_call_for_evidence
+        - call_for_evidence_outcome
 
 content_purpose_supergroup:
   name: "Content Purpose Supergroup"
@@ -326,6 +341,9 @@ content_purpose_supergroup:
         - open_consultation
         - closed_consultation
         - consultation_outcome
+        - open_call_for_evidence
+        - closed_call_for_evidence
+        - call_for_evidence_outcome
     - id: research_and_statistics
       document_types:
         - independent_report

--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -10,6 +10,7 @@ en:
   content_purpose_subgroup:
     announcements: Announcements
     business_support: Business funds and grants
+    calls_for_evidence: Calls for evidence
     consultations: Consultations
     decisions: Decisions
     freedom_of_information_releases: Freedom of information releases

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -32,7 +32,7 @@ describe GovukDocumentTypes do
     it "returns subgroups registered to the specified supergroups" do
       subgroups = described_class.supergroup_subgroups("policy_and_engagement")
 
-      expect(subgroups).to contain_exactly("policy", "consultations")
+      expect(subgroups).to contain_exactly("policy", "consultations", "calls_for_evidence")
     end
   end
 


### PR DESCRIPTION
The call for evidence document type is a sibling of the consultation document type and therefore appears in the same types and group