### PR TITLE
Use `main` branch for Content Schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: alphagov/publishing-api
-          ref: deployed-to-production
+          ref: main
           path: tmp/publishing-api
       - uses: ruby/setup-ruby@v1
         with:

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -162,7 +162,6 @@ content_purpose_subgroup:
     - id: news
       document_types:
         - case_study
-        - news_article
         - news_story
         - press_release
         - world_news_story
@@ -190,7 +189,6 @@ content_purpose_subgroup:
         - completed_transaction
         - local_transaction
         - form
-        - calculator
         - smart_answer
         - simple_smart_answer
         - place
@@ -235,7 +233,6 @@ content_purpose_subgroup:
         - consultation_outcome
     - id: research
       document_types:
-        - dfid_research_output
         - independent_report
         - research
     - id: statistics
@@ -269,7 +266,6 @@ content_purpose_supergroup:
       document_types:
         - medical_safety_alert
         - drug_safety_update
-        - news_article
         - news_story
         - press_release
         - world_news_story
@@ -294,7 +290,6 @@ content_purpose_supergroup:
         - completed_transaction
         - local_transaction
         - form
-        - calculator
         - smart_answer
         - simple_smart_answer
         - place
@@ -333,7 +328,6 @@ content_purpose_supergroup:
         - consultation_outcome
     - id: research_and_statistics
       document_types:
-        - dfid_research_output
         - independent_report
         - research
         - statistics

--- a/spec/govuk_document_types_spec.rb
+++ b/spec/govuk_document_types_spec.rb
@@ -58,7 +58,6 @@ describe GovukDocumentTypes do
 
       expect(document_types)
         .to contain_exactly(
-          "dfid_research_output",
           "impact_assessment",
           "independent_report",
           "policy_paper",


### PR DESCRIPTION
The CI pipeline was checking out the `deployed-to-production` branch of the Publishing API repository to lint the document types against defined content schemas.

However, the `deployed-to-production` branch no longer exists in GOV.UK repositories. This is an implementation detail from the old EC2-based hosting platform, but the new EKS hosting environment simply deploys the `main` branch without tagging releases.

We therefore need to switch this repository's CI pipeline over to use the `main` branch of Publishing API, so it picks up the current version of the GOV.UK content schemas.