### PR TITLE
Release version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.0.0
 
 * BREAKING: Drop support for Ruby 2.7 ([PR #89](https://github.com/alphagov/govuk_document_types/pull/89))
 * Added new call for evidence document type to supertypes and group ([PR #91](https://github.com/alphagov/govuk_document_types/pull/91))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-* Drop support for Ruby 2.7.
+* BREAKING: Drop support for Ruby 2.7 ([PR #89](https://github.com/alphagov/govuk_document_types/pull/89))
+* Added new call for evidence document type to supertypes and group ([PR #91](https://github.com/alphagov/govuk_document_types/pull/91))
 
 # 1.0.1
 

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "1.0.1".freeze
+  VERSION = "2.0.0".freeze
 end


### PR DESCRIPTION
# Release 2.0.0

* BREAKING: Drop support for Ruby 2.7 ([PR #89](https://github.com/alphagov/govuk_document_types/pull/89))
* Added new call for evidence document type to supertypes and group ([PR #91](https://github.com/alphagov/govuk_document_types/pull/91))

# Why

This PR tags a new major release of the `govuk_document_types` gem. This is a **major** release because it drops support for Ruby 2.7, which has reached end-of-life status.

It's been a couple of years since this gem has been released. The driver for us to tag this new release is so that we can include the new 'Call for evidence' document type into the 'Policy and engagement' supergroup. Calls for evidence are very similar to consultations, so this is the most logical way for them to be grouped and shown on the frontend of GOV.UK.

More information in Trello: https://trello.com/c/VL1HH4lF/1494-release-a-new-version-of-the-gem-govukdocumenttypes