### PR TITLE
Remove specialist topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* BREAKING: Remove specialist topics ([PR #108](https://github.com/alphagov/govuk_document_types/pull/108))
+
 # 2.0.0
 
 * BREAKING: Drop support for Ruby 2.7 ([PR #89](https://github.com/alphagov/govuk_document_types/pull/89))

--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -17,7 +17,6 @@ user_journey_document_supertype:
         - service_manual_topic
         - services_and_information
         - taxon
-        - topic
         - topical_event
 
 email_document_supertype:


### PR DESCRIPTION
## What

Removing specialist topics from publishing-api, impacted the test in govuk_document_types and it is now failing. Specialist topics have not been removed from this repository. This PR removes them. The impact of this change needs to be carefully considered before this PR is merged and it needs to be approved.

## Why

In order to fix the [failing test](https://github.com/alphagov/govuk_document_types/actions/runs/9111652755/job/25049222256?pr=107).
