### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 3.0.0
 
 * BREAKING: Remove specialist topics ([PR #108](https://github.com/alphagov/govuk_document_types/pull/108))
 

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "2.0.0".freeze
+  VERSION = "3.0.0".freeze
 end


### PR DESCRIPTION
# Release 3.0.0

* BREAKING: Remove specialist topics ([PR #108](https://github.com/alphagov/govuk_document_types/pull/108))