### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 3.1.0
 
 * Drop support for Ruby 3.1, keep supporting Ruby 3.2, use Ruby 3.3 as default https://github.com/alphagov/govuk_document_types/pull/120
 

--- a/lib/govuk_document_types/version.rb
+++ b/lib/govuk_document_types/version.rb
@@ -1,3 +1,3 @@
 module GovukDocumentTypes
-  VERSION = "3.0.1".freeze
+  VERSION = "3.1.0".freeze
 end


### PR DESCRIPTION
* Drop support for Ruby 3.1, keep supporting Ruby 3.2, use Ruby 3.3 as default https://github.com/alphagov/govuk_document_types/pull/120